### PR TITLE
Add wildcard topics

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,15 +18,15 @@ RadioRadio is also really tiny:
 	<tbody>
 		<tr>
 			<th>Uncompressed</th>
-			<td>1,447 bytes</td>
+			<td>1,651 bytes</td>
 		</tr>
 		<tr>
 			<th>Minified</th>
-			<td>805 bytes</td>
+			<td>910 bytes</td>
 		</tr>
 		<tr>
-			<th>Minifed and gzipped</th>
-			<td>469 bytes</td>
+			<th>Minified and gzipped</th>
+			<td>543 bytes</td>
 		</tr>
 	</tbody>
 </table>
@@ -56,6 +56,10 @@ RadioRadio.subscribe(topic, subscriber);
 
 Topics must be strings of any length (e.g. `foo`) made up of letters, numbers, and underscores. Topics may also be organized into namespaces using a `.` as a separator (e.g. `foo.bar`).
 
+Topics within a namespace may themselves act as namespaces. For example, a subscribed topic `foo.bar.biz` exists in the `foo` _and_ `foo.bar` namespaces. Note that this structure will affect publication (see [Publishing](#Publishing) below).
+
+Wildcard topics within a namespace (e.g. `foo.*`, `foo.bar.*`) are also allowed. See [Publishing](#publishing) below for more on when these topics are published.
+
 #### The `subscriber` argument
 
 A function to execute when `topic` is published. Subscribers accept a single argument (`data`) passed on from the `publish` method.
@@ -77,13 +81,29 @@ The topic to which you wish to publish. When using namespaced topics (e.g. `foo.
 RadioRadio.publish('foo.bar', data);
 ```
 
-…or, to a namespace:
+…or, to a topic and any topics within its namespace:
 
 ```js
 RadioRadio.publish('foo', data);
 ```
 
-In the latter case, publishing to the namespace `foo` will publish to _all_ topics within that namespace (e.g. `foo.bar`, `foo.biz`, `foo.baz`).
+Publishing to the namespace `foo` will publish to `foo` and _all_ topics namespaced to `foo` (e.g. `foo.bar`, `foo.biz`, `foo.baz`). As mentioned above in [Subscribing](#subscribing), topics may be deeply nested (e.g. `foo.bar.biz`) which will affect publishing to namespaces:
+
+```js
+RadioRadio.publish('foo', data);     // publishes to `foo`, `foo.bar`, `foo.bar.biz`
+RadioRadio.publish('foo.bar', data); // publishes to `foo.bar`, `foo.bar.biz`
+```
+
+Wildcard topics within a namespace (e.g. `foo.*`) will be published alongside adjacent (e.g. `foo.bar`, `foo.biz`) published topics:
+
+```js
+RadioRadio.subscribe('foo.bar', subscriber);
+RadioRadio.subscribe('foo.*', wildcardSubscriber);
+
+RadioRadio.publish('foo.bar', data); // publishes to `foo.bar` and `foo.*`
+```
+
+Note that topics are published in the order in which they were originally subscribed.
 
 #### The `data` argument
 

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ RadioRadio.subscribe(topic, subscriber);
 
 Topics must be strings of any length (e.g. `foo`) made up of letters, numbers, and underscores. Topics may also be organized into namespaces using a `.` as a separator (e.g. `foo.bar`).
 
-Topics within a namespace may themselves act as namespaces. For example, a subscribed topic `foo.bar.biz` exists in the `foo` _and_ `foo.bar` namespaces. Note that this structure will affect publication (see [Publishing](#Publishing) below).
+Topics within a namespace may themselves act as namespaces. For example, a subscribed topic `foo.bar.biz` exists in the `foo` _and_ `foo.bar` namespaces. Note that this structure will affect publication (see [Publishing](#publishing) below).
 
 Wildcard topics within a namespace (e.g. `foo.*`, `foo.bar.*`) are also allowed. See [Publishing](#publishing) below for more on when these topics are published.
 

--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "radioradio",
-  "version": "0.1.2",
+  "version": "0.2.0",
   "homepage": "https://github.com/jgarber623/RadioRadio",
   "authors": [
     "Jason Garber <jason@sixtwothree.org> (http://sixtwothree.org)"

--- a/dist/radioradio.min.js
+++ b/dist/radioradio.min.js
@@ -1,5 +1,5 @@
 /*!
- *  RadioRadio 0.1.2
+ *  RadioRadio 0.2.0
  *
  *  A very basic JavaScript PubSub library.
  *
@@ -10,4 +10,4 @@
  *  RadioRadio may be freely distributed under the MIT license.
  */
 
-!function(n,t){"function"==typeof define&&define.amd?define([],t):"object"==typeof exports?module.exports=t():n.RadioRadio=t()}(this,function(){"use strict";var n={},t=function(t){return Object.keys(n).filter(function(n){return n.match(e(t))})},e=function(n){return new RegExp(n)};return{publish:function(e,r){var u=t(e);return u.length?(u.forEach(function(t){n[t](r)}),u):!1},subscribe:function(t,r){return"string"==typeof t&&t.match(e())&&"function"==typeof r?(n[t]=r,t):!1},unsubscribe:function(t){return delete n[t]}}});
+!function(n,t){"function"==typeof define&&define.amd?define([],t):"object"==typeof exports?module.exports=t():n.RadioRadio=t()}(this,function(){"use strict";var n={},t=function(n){return"string"==typeof n&&n.match(/^\w+(\.\w+)*(\.\*)?$/)},e=function(t){var e=new RegExp("^"+t+"(\\.\\w+)*$"),r=/\.\w+$/,u=t.match(r)?t.replace(r,".*"):!1;return Object.keys(n).filter(function(n){return n===u||n.match(e)})};return{publish:function(r,u){var i=t(r)?e(r):[];return i.length?(i.forEach(function(t){n[t](u)}),i):!1},subscribe:function(e,r){return t(e)&&"function"==typeof r?(n[e]=r,e):!1},unsubscribe:function(t){return delete n[t]}}});

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "radioradio",
-  "version": "0.1.2",
+  "version": "0.2.0",
   "description": "A very basic JavaScript PubSub library.",
   "main": "dist/radioradio.js",
   "directories": {

--- a/src/radioradio.js
+++ b/src/radioradio.js
@@ -11,23 +11,27 @@
 
 	var topics = {};
 
-	var filterTopics = function(topic) {
-		return Object.keys(topics).filter(function(key) {
-			return key.match(topicRegExp(topic));
-		});
+	var topicIsValid = function(topic) {
+		return typeof topic === 'string' && topic.match(/^\w+(\.\w+)*(\.\*)?$/);
 	};
 
-	var topicRegExp = function(topic) {
-		return new RegExp('^' + topic ? topic : '\\w+' + '(\\.\\w*)*?$');
+	var setPublishableQueue = function(topic) {
+		var topicRegExp = new RegExp('^' + topic + '(\\.\\w+)*$'),
+			wildcardRegExp = /\.\w+$/,
+			wildcardTopic = topic.match(wildcardRegExp) ? topic.replace(wildcardRegExp, '.*') : false;
+
+		return Object.keys(topics).filter(function(key) {
+			return key === wildcardTopic || key.match(topicRegExp);
+		});
 	};
 
 	return {
 		publish: function(topic, data) {
-			var queue = filterTopics(topic);
+			var queue = topicIsValid(topic) ? setPublishableQueue(topic) : [];
 
 			if (queue.length) {
-				queue.forEach(function(element) {
-					topics[element](data);
+				queue.forEach(function(key) {
+					topics[key](data);
 				});
 
 				return queue;
@@ -37,7 +41,7 @@
 		},
 
 		subscribe: function(topic, subscriber) {
-			if (typeof topic === 'string' && topic.match(topicRegExp()) && typeof subscriber === 'function') {
+			if (topicIsValid(topic) && typeof subscriber === 'function') {
 				topics[topic] = subscriber;
 
 				return topic;


### PR DESCRIPTION
This PR resolves @keekerdc's issue #1.

Wildcard topics (e.g. `foo.*`) are now a thing you can subscribe to and will publish when adjacent namespaces topics (e.g. `foo.bar`, `foo.biz`) are published.

You can also directly publish to the wildcard topic but that will function as a typical, non-wildcard topic publication.